### PR TITLE
Changed 'last_page' variable to new 2.4 syntax of last_page_visited

### DIFF
--- a/system/expressionengine/third_party/mo_variables/ext.mo_variables.php
+++ b/system/expressionengine/third_party/mo_variables/ext.mo_variables.php
@@ -234,7 +234,7 @@ class Mo_variables_ext
 	{
 		$variables = array(
 			//'current_page' => 0,
-			'last_page' => 1,
+			'last_page_visited' => 1,
 			'one_page_ago' => 1,
 			'two_pages_ago' => 2,
 			'three_pages_ago' => 3,


### PR DESCRIPTION
Hi Rob, there was a paging issue caused by updates to EE 2.4. I've added the small code tweak to the code.
