### PR TITLE
Use new XSS function in EE3

### DIFF
--- a/system/expressionengine/third_party/mo_variables/addon.setup.php
+++ b/system/expressionengine/third_party/mo_variables/addon.setup.php
@@ -5,7 +5,7 @@ return array(
     'author_url'     => 'https://github.com/rsanchez',
     'name'           => 'Mo\' Variables',
     'description'    => 'Adds many useful global variables and conditionals to use in your templates.',
-    'version'        => '1.3.0',
+    'version'        => '1.3.2',
     'namespace'      => '\\',
     'settings_exist' => TRUE,
 );

--- a/system/expressionengine/third_party/mo_variables/ext.mo_variables.php
+++ b/system/expressionengine/third_party/mo_variables/ext.mo_variables.php
@@ -4,7 +4,7 @@ class Mo_variables_ext
 {
 	public $settings = array();
 	public $name = 'Mo\' Variables';
-	public $version = '1.3.1';
+	public $version = '1.3.2';
 	public $description = 'Adds many useful global variables and conditionals to use in your templates.';
 	public $settings_exist = 'y';
 	public $docs_url = 'https://git.io/mo';
@@ -305,7 +305,11 @@ class Mo_variables_ext
 			//this way of handling conditionals works best in the EE template parser
 			if ( ! is_bool($value))
 			{
-				$value = ($xss_clean) ? $this->EE->security->xss_clean($value) : $value;
+				if (APP_VER > 3) {
+					$value = ($xss_clean) ? ee('Security/XSS')->clean($value) : $value;
+				} else {
+					$value = ($xss_clean) ? $this->EE->security->xss_clean($value) : $value;
+				}
 			}
 
 			$this->EE->config->_global_vars[$key] = $value;


### PR DESCRIPTION
Handle the following developer log entry: 

Deprecated function xss_clean() called in ../mo_variables/ext.mo_variables.php on line 311.
Deprecated since 3.0. Use ee('Security/XSS')->clean() instead.